### PR TITLE
Flutter 0.9.6 and Android SDK 27

### DIFF
--- a/0.9.6/Dockerfile
+++ b/0.9.6/Dockerfile
@@ -1,7 +1,7 @@
 FROM cirrusci/flutter:base
 
 ENV FLUTTER_HOME ${HOME}/sdks/flutter
-ENV FLUTTER_VERSION 0.5.6
+ENV FLUTTER_VERSION 0.9.6
 
 RUN git clone --branch v${FLUTTER_VERSION} https://github.com/flutter/flutter.git ${FLUTTER_HOME}
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # docker-images-flutter
+
 Docker Images for Flutter

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM cirrusci/android-sdk:26
+FROM cirrusci/android-sdk:27
 
 RUN sudo apt-get update \
     && sudo apt-get install -y --allow-unauthenticated --no-install-recommends lib32stdc++6 libstdc++6 libglu1-mesa locales \

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -6,4 +6,4 @@ set -e
 docker pull cirrusci/flutter:base
 
 docker build --tag cirrusci/flutter:base base
-docker build --tag cirrusci/flutter:0.5.6 --tag cirrusci/flutter:latest 0.5.6
+docker build --tag cirrusci/flutter:0.9.6 --tag cirrusci/flutter:latest 0.9.6

--- a/push_docker.sh
+++ b/push_docker.sh
@@ -10,5 +10,5 @@ fi
 docker login --username $DOCKER_USER_NAME --password $DOCKER_PASSWORD
 
 docker push cirrusci/flutter:base
-docker push cirrusci/flutter:0.5.6
+docker push cirrusci/flutter:0.9.6
 docker push cirrusci/flutter:latest


### PR DESCRIPTION
Hi,

This a request to upgrade the Flutter and the Android SDK verions to their latest versions.

I'm trying to test my project and I get this error:

```
Running "flutter packages get" in cirrus-ci-build...
The current Dart SDK version is 2.0.0-dev.63.0.flutter-4c9689c1d2.
Because numcol requires SDK version >=2.0.0-dev.68.0 <3.0.0, version solving failed.
```

I tried it in a container with the new versions upgraded and it runs, it would be nice to continue using your image rather than having my own.

Thanks in advance.