### PR TITLE
Bumps to 0.10.2 Flutter, bumps SDK:28 based off of cirrus PR

### DIFF
--- a/0.10.2/Dockerfile
+++ b/0.10.2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cirrusci/flutter:base
 
 ENV FLUTTER_HOME ${HOME}/sdks/flutter
-ENV FLUTTER_VERSION 0.5.6
+ENV FLUTTER_VERSION 0.10.2
 
 RUN git clone --branch v${FLUTTER_VERSION} https://github.com/flutter/flutter.git ${FLUTTER_HOME}
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM cirrusci/android-sdk:26
+FROM cirrusci/android-sdk:28
 
 RUN sudo apt-get update \
     && sudo apt-get install -y --allow-unauthenticated --no-install-recommends lib32stdc++6 libstdc++6 libglu1-mesa locales \

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -6,4 +6,4 @@ set -e
 docker pull cirrusci/flutter:base
 
 docker build --tag cirrusci/flutter:base base
-docker build --tag cirrusci/flutter:0.5.6 --tag cirrusci/flutter:latest 0.5.6
+docker build --tag cirrusci/flutter:0.10.2 --tag cirrusci/flutter:latest 0.10.2

--- a/push_docker.sh
+++ b/push_docker.sh
@@ -10,5 +10,5 @@ fi
 docker login --username $DOCKER_USER_NAME --password $DOCKER_PASSWORD
 
 docker push cirrusci/flutter:base
-docker push cirrusci/flutter:0.5.6
+docker push cirrusci/flutter:0.10.2
 docker push cirrusci/flutter:latest


### PR DESCRIPTION
This bumps the sdk to `28` and persists the previous PR for `0.10.2` on flutter from another contributor.

Dependent on [https://github.com/cirruslabs/docker-images-android/pull/1](https://github.com/cirruslabs/docker-images-android/pull/1)