### PR TITLE
`flutter test --coverage` is natively supported, but the result need to be interpreted

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,6 +6,7 @@ ENV LANGUAGE en_US:en
 
 RUN sudo apt-get update \
     && sudo apt-get install -y --allow-unauthenticated --no-install-recommends lib32stdc++6 libstdc++6 libglu1-mesa locales \
+        lcov \
     && sudo rm -rf /var/lib/apt/lists/*
 
 RUN sudo sh -c 'echo "en_US.UTF-8 UTF-8" > /etc/locale.gen' && \


### PR DESCRIPTION
e.g `genhtml coverage/lcov.info --function-coverage --branch-coverage --output-directory reports`, `genhtml` is only availble in `lcov` package