### PR TITLE
support running test on browser

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,6 +7,7 @@ ENV LANGUAGE en_US:en
 RUN sudo apt-get update \
     && sudo apt-get install -y --allow-unauthenticated --no-install-recommends lib32stdc++6 libstdc++6 libglu1-mesa locales \
         lcov \
+        chromium \
     && sudo rm -rf /var/lib/apt/lists/*
 
 RUN sudo sh -c 'echo "en_US.UTF-8 UTF-8" > /etc/locale.gen' && \


### PR DESCRIPTION
`pub run test test -p chromium` can be run if the package has `dart_test.yaml` with the following content:
```yaml
define_platforms:
  chromium:
    name: Chromium
    extends: chrome
    settings:
      arguments: --no-sandbox
      executable:
        linux: chromium
```

Close #17