### PR TITLE
Added the working directory so that the command works right out the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 You can either [use it in CI](https://cirrus-ci.org/examples/#flutter) or run locally via Docker:
 
 ```bash
-docker run --rm -it -v ${PWD}:/build cirrusci/flutter:stable flutter test
+docker run --rm -it -v ${PWD}:/build --workdir /build cirrusci/flutter:stable flutter test
 ```
 
 The example above simply mount current working directory and runs `flutter test`


### PR DESCRIPTION
Command should have the `--workdir /build` definition in it, or it will fail as I demonstrated in [this issue](https://github.com/cirruslabs/docker-images-flutter/issues/27).