### PR TITLE
Bump versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,12 +7,12 @@ flutter_docker_builder:
     # from https://flutter.dev/docs/development/tools/sdk/releases
     matrix:
     - DOCKER_TAG: latest
-      FLUTTER_VERSION: v1.9.1+hotfix.6
+      FLUTTER_VERSION: v1.12.13+hotfix.5
     - DOCKER_TAG: stable
-      FLUTTER_VERSION: v1.9.1+hotfix.6
+      FLUTTER_VERSION: v1.12.13+hotfix.5
     - DOCKER_TAG: beta
-      FLUTTER_VERSION: v1.12.13+hotfix.2
+      FLUTTER_VERSION: v1.12.13+hotfix.6
     - DOCKER_TAG: dev
-      FLUTTER_VERSION: v1.12.16
+      FLUTTER_VERSION: v1.13.0
   build_script: ./build_docker.sh
   push_script: ./push_docker.sh


### PR DESCRIPTION
v1.12.13 is released in stable channel.

https://flutter.dev/docs/development/tools/sdk/releases