### PR TITLE
Bump versions March 2020

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,12 +7,12 @@ flutter_docker_builder:
     # from https://flutter.dev/docs/development/tools/sdk/releases
     matrix:
     - DOCKER_TAG: latest
-      FLUTTER_VERSION: v1.12.13+hotfix.8
+      FLUTTER_VERSION: v1.16.1
     - DOCKER_TAG: stable
       FLUTTER_VERSION: v1.12.13+hotfix.8
     - DOCKER_TAG: beta
-      FLUTTER_VERSION: v1.14.6
+      FLUTTER_VERSION: v1.15.17
     - DOCKER_TAG: dev
-      FLUTTER_VERSION: v1.15.3
+      FLUTTER_VERSION: v1.16.1
   build_script: ./build_docker.sh
   push_script: ./push_docker.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ flutter_docker_builder:
     # from https://flutter.dev/docs/development/tools/sdk/releases
     matrix:
     - DOCKER_TAG: latest
-      FLUTTER_VERSION: v1.16.1
+      FLUTTER_VERSION: v1.12.13+hotfix.8
     - DOCKER_TAG: stable
       FLUTTER_VERSION: v1.12.13+hotfix.8
     - DOCKER_TAG: beta


### PR DESCRIPTION
Bumping all versions except for stable (unchanged) as of March 24, 2020.