### PR TITLE
Splits SDK Dockerfile ENV

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -3,8 +3,8 @@ FROM cirrusci/android-sdk:29
 ARG flutter_version
 
 ENV FLUTTER_HOME=${HOME}/sdks/flutter \
-    FLUTTER_ROOT=$FLUTTER_HOME \
     FLUTTER_VERSION=$flutter_version
+ENV FLUTTER_ROOT=$FLUTTER_HOME
 
 ENV PATH ${PATH}:${FLUTTER_HOME}/bin:${FLUTTER_HOME}/bin/cache/dart-sdk/bin
 


### PR DESCRIPTION
Apparently:

```Dockerfile
ENV A='a' \
    B=$A
```

```bash
# echo $A
a
# echo $B

```

B will have no value since A hasn't been populated yet