### PR TITLE
Clone only the tip of a branch

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -8,6 +8,6 @@ ENV FLUTTER_ROOT=$FLUTTER_HOME
 
 ENV PATH ${PATH}:${FLUTTER_HOME}/bin:${FLUTTER_HOME}/bin/cache/dart-sdk/bin
 
-RUN git clone --branch ${FLUTTER_VERSION} https://github.com/flutter/flutter.git ${FLUTTER_HOME}
+RUN git clone --branch ${FLUTTER_VERSION} --depth 1 https://github.com/flutter/flutter.git ${FLUTTER_HOME}
 
 RUN yes | flutter doctor --android-licenses && flutter doctor


### PR DESCRIPTION
To make the Docker image smaller. See https://flutter.dev/docs/get-started/install/linux#get-sdk