### PR TITLE
Predownload all dependencies flutter needs

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -14,4 +14,7 @@ RUN git clone --branch ${FLUTTER_VERSION} https://github.com/flutter/flutter.git
 
 RUN yes | flutter doctor --android-licenses \
     && flutter doctor \
+    && flutter precache \
+    && sdkmanager "--update" "--verbose" \
+    && sdkmanager "build-tools;28.0.3" "platform-tools" "platforms;android-28" "platforms;android-29" "extras;android;m2repository" "extras;google;google_play_services" "extras;google;m2repository" \
     && chown -R root:root ${FLUTTER_HOME}


### PR DESCRIPTION
This PR fixes the compilation always being slow. https://github.com/cirruslabs/docker-images-flutter/issues/115

Issue was caused by missing platforms android 28 and 29. And also by build-tools version 28 being missing. So flutter autodownloaded it. This predownloads it as part of the docker image.