### PR TITLE
windows desktop: add Google root cert gtsr1 to future proof pub get

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -3,7 +3,7 @@
 These docker containers are built on containers from [cirrusci](https://hub.docker.com/u/cirrusci) ([cirruslabs](https://github.com/cirruslabs)).
 
 - linux-dev is just cirrusci/flutter:dev + apt installing the needed utils
-- windows-dev-sdk30-fdev2.2rc is cirrusci/android-sdk:30-windowsservercore-2019 with Visual Studio 16, and Flutter dev (2.2rc)
+- windows-dev-sdk30-fdev2.3rc is cirrusci/android-sdk:30-windowsservercore-2019 with Visual Studio 16, Flutter dev (2.3rc), and Google Root cert gtsr1 (for future proofing pub get)
 
 These docker containers are both being used with Drone CI to build Flutter desktop apps for Linux and Windows. Simply run `flutter build` with the appropriate OS. These containers should work with any other Docker based automated build system such as Gitlab and others.
 

--- a/desktop/windows/Dockerfile
+++ b/desktop/windows/Dockerfile
@@ -24,6 +24,12 @@ RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache \
     --installPath C:\BuildTools \
      || IF "%ERRORLEVEL%"=="3010" EXIT 0
 
+# Install Google Root R1 cert so pub.dartlang.org stays working
+
+ADD https://pki.goog/repo/certs/gtsr1.pem C:/TEMP/gtsr1.pem
+RUN powershell.exe -Command \
+        Import-Certificate -FilePath C:\TEMP\gtsr1.pem -CertStoreLocation Cert:\LocalMachine\Root
+
 # Install Flutter
 
 RUN setx path "%path%;C:\flutter\bin;C:\flutter\bin\cache\dart-sdk\bin;"


### PR DESCRIPTION
...calls to pub.dartlang.org whos cert changes every few months

We started getting build fails because pub.dartlang.org's cert changed and the container couldn't auth the cert. Importing the google root cert for it fixed this