### PR TITLE
build: bump dev channel to 2.3.0-24.1.pre

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,6 @@ docker_builder:
     - DOCKER_TAG: beta
       FLUTTER_VERSION: 2.2.2
     - DOCKER_TAG: dev
-      FLUTTER_VERSION: 2.3.0-24.0.pre
+      FLUTTER_VERSION: 2.3.0-24.1.pre
   build_script: ./build_docker.sh
   push_script: ./push_docker.sh


### PR DESCRIPTION
Bump dev channel to from [2.3.0-24.0.pre](https://github.com/flutter/flutter/releases/tag/2.3.0-24.0.pre) to [2.3.0-24.1.pre](https://github.com/flutter/flutter/releases/tag/2.3.0-24.1.pre)