### PR TITLE
build: bump stable channel to 2.2.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,12 +8,12 @@ docker_builder:
     # from https://flutter.dev/docs/development/tools/sdk/releases
     matrix:
     - DOCKER_TAG: latest
-      FLUTTER_VERSION: 2.2.2
+      FLUTTER_VERSION: 2.2.3
     - DOCKER_TAG: stable
-      FLUTTER_VERSION: 2.2.2
+      FLUTTER_VERSION: 2.2.3
     - DOCKER_TAG: beta
-      FLUTTER_VERSION: 2.2.2
-    - DOCKER_TAG: dev
       FLUTTER_VERSION: 2.3.0-24.1.pre
+    - DOCKER_TAG: dev
+      FLUTTER_VERSION: 2.3.0-24.0.pre
   build_script: ./build_docker.sh
   push_script: ./push_docker.sh


### PR DESCRIPTION
This commit also bumps the `beta` channel to `2.3.0-24.1.pre` and lowers the version of `dev` channel back to `2.3.0-24.0.pre` to match the release channel here https://flutter.dev/docs/development/tools/sdk/releases?tab=linux