### PR TITLE
Update beta channel to latest, remove dev channel

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,8 +12,6 @@ docker_builder:
     - DOCKER_TAG: stable
       FLUTTER_VERSION: 2.10.2
     - DOCKER_TAG: beta
-      FLUTTER_VERSION: 2.10.0-0.3.pre
-    - DOCKER_TAG: dev
-      FLUTTER_VERSION: 2.10.0-0.3.pre
+      FLUTTER_VERSION: 2.11.0-0.1.pre
   build_script: ./build_docker.sh
   push_script: ./push_docker.sh


### PR DESCRIPTION
I was using the :beta tag of this docker image, but it was behind the stable tag.. Weirdly enough.
So I updated it to the latest version:
https://docs.flutter.dev/development/tools/sdk/releases

While doing that I also noticed that the dev channel was still part of this build.. But the dev-channel has been removed:

https://github.com/flutter/flutter/issues/94962