### PR TITLE
Update beta tag to 3.1.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,6 @@ docker_builder:
     - DOCKER_TAG: stable
       FLUTTER_VERSION: 3.0.1
     - DOCKER_TAG: beta
-      FLUTTER_VERSION: 2.13.0-0.4.pre
+      FLUTTER_VERSION: 3.1.0
   build_script: ./build_docker.sh
   push_script: ./push_docker.sh


### PR DESCRIPTION
Latest Beta is 3.1.0

https://docs.flutter.dev/development/tools/sdk/releases?tab=linux