### PR TITLE
chore: bump to Flutter 3.10.6 and 3.13.0-0.1.pre

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,11 +7,11 @@ docker_builder:
     # from https://flutter.dev/docs/development/tools/sdk/releases
     matrix:
     - DOCKER_TAG: latest
-      FLUTTER_VERSION: 3.10.5
+      FLUTTER_VERSION: 3.10.6
     - DOCKER_TAG: stable
-      FLUTTER_VERSION: 3.10.5
+      FLUTTER_VERSION: 3.10.6
     - DOCKER_TAG: beta
-      FLUTTER_VERSION: 3.12.0-1.1.pre
+      FLUTTER_VERSION: 3.13.0-0.1.pre
   version_script: docker --version
   setup_script:
     - docker buildx create --name multibuilder


### PR DESCRIPTION
I bumped the stable Flutter version to 3.10.6 and the beta to 3.13.0-0.1.pre.