### PR TITLE
Automatically check for new Flutter versions

### DIFF
--- a/.github/workflows/check_flutter_versions.yml
+++ b/.github/workflows/check_flutter_versions.yml
@@ -1,0 +1,34 @@
+name: "Check Flutter versions"
+on:
+  schedule:
+    # Every 2 hours
+    - cron: "0 */2 * * *"
+  workflow_dispatch:
+
+jobs:
+  check_versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install yq and jq
+      - name: Install yq and jq
+        run: |
+          mkdir -p ~/bin
+          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O ~/bin/yq
+          chmod +x ~/bin/yq
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+          sudo apt-get install -y jq curl
+
+      - name: Check for new Flutter versions 
+        run: sh scripts/update_flutter_versions.sh
+
+      # Create a Pull Request if there are any changes.
+      # This is automatically checked internally
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: Update Flutter version"
+          title: "chore: Update Flutter version"
+          branch: "chore/update-flutter-version"

--- a/scripts/update_flutter_versions.sh
+++ b/scripts/update_flutter_versions.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+# This script fetches the latest version of a the stable and beta flutter channels
+# and edits the .cirrus.yml file with those versions
+
+releases_json=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json)
+
+# This function edits the .cirrus.yml file with the given flutter version for the given docker tag
+edit_cirrus_file_for_tag() {
+    cirrus_file=".cirrus.yml"
+    docker_tag=$1
+    version=$2
+
+    # env for yq
+    docker_tag=$docker_tag version=$version \
+        yq -i '(.docker_builder.env.matrix[] | select(.DOCKER_TAG == env(docker_tag)) | .FLUTTER_VERSION) = env(version)' $cirrus_file
+}
+
+# This function fetches the latest version of a particular channel (stable, beta) for Flutter
+get_latest_version_in_channel() {
+    channel=$1
+    # This contains the hash of the latest version in the channel
+    channel_hash=$(echo "$releases_json" | jq -r '.current_release.'"$channel")
+    # Look for the version corresponding to the hash in the list of releases
+    version=$(echo "$releases_json" | jq -r --arg HASH "$channel_hash" \
+        '.releases[] | select(.hash == $HASH).version')
+
+    # check not empty
+    if [ -z "$version" ]; then
+        echo "Error fetching latest version in channel $channel"
+        exit 1
+    fi
+
+    echo "$version"
+}
+
+stable_version=$(get_latest_version_in_channel "stable")
+beta_version=$(get_latest_version_in_channel "beta")
+
+echo "Latest beta version: $beta_version"
+echo "Latest stable version: $stable_version"
+
+edit_cirrus_file_for_tag "stable" "$stable_version"
+edit_cirrus_file_for_tag "latest" "$stable_version"
+edit_cirrus_file_for_tag "beta" "$beta_version"
+
+exit 0


### PR DESCRIPTION
Hello!
This PR creates a Github Action workflow that will create a PR that updates the stable and beta Flutter channels everytime they change.
The workflow is scheduled to run every 2 hours.

The Flutter versions are extracted from https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json  
The json contains a section with the latest beta and stable hashes.

It uses jq and yq to parse JSON and YAML, to parse the releases and to edit the cirrus.yml file.

You can see a sample of one these PRs here: https://github.com/davidmartos96/docker-images-flutter/pull/2

Hope it helps, it will make the process more automatic :smile: 