### PR TITLE
chore(deps): update Flutter from 3.16.2 to 3.16.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,9 +7,9 @@ docker_builder:
     # from https://flutter.dev/docs/development/tools/sdk/releases
     matrix:
     - DOCKER_TAG: latest
-      FLUTTER_VERSION: 3.16.2
+      FLUTTER_VERSION: 3.16.3
     - DOCKER_TAG: stable
-      FLUTTER_VERSION: 3.16.2
+      FLUTTER_VERSION: 3.16.3
     - DOCKER_TAG: beta
       FLUTTER_VERSION: 3.17.0-0.0.pre
   version_script: docker --version


### PR DESCRIPTION
Waiting for #297 approval, here is the latest Flutter version