### PR TITLE
Run `flutter precache` at image build time

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -16,3 +16,5 @@ RUN git clone --depth 1 --branch ${FLUTTER_VERSION} https://github.com/flutter/f
 RUN yes | flutter doctor --android-licenses \
     && flutter doctor \
     && chown -R root:root ${FLUTTER_HOME}
+
+RUN flutter precache --android


### PR DESCRIPTION
`flutter precache` is called anyway during the first `flutter run` anyway, which adds time (just now I checked with my very good connection and `flutter precache` took additional 40s). 

So I think it makes sense to add it at build time.