### PR TITLE
Fixes Flutter git clone while Flutter 3.29.1 is not out

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cirruslabs/android-sdk:34
+FROM ghcr.io/cirruslabs/android-sdk:35
 
 LABEL org.opencontainers.image.source=https://github.com/cirruslabs/docker-images-flutter
 USER root
@@ -12,6 +12,11 @@ ENV FLUTTER_ROOT=$FLUTTER_HOME
 ENV PATH ${PATH}:${FLUTTER_HOME}/bin:${FLUTTER_HOME}/bin/cache/dart-sdk/bin
 
 RUN git clone --depth 1 --branch ${FLUTTER_VERSION} https://github.com/flutter/flutter.git ${FLUTTER_HOME}
+
+# Temporary workaround for https://github.com/flutter/flutter/issues/163308#issuecomment-2676366371
+# It will be fixed in Flutter 3.29.1
+# Removing this triggers fetching the correct Flutter engine version 
+RUN cd ${FLUTTER_HOME} && rm engine/src/.gn
 
 RUN yes | flutter doctor --android-licenses \
     && flutter doctor \


### PR DESCRIPTION
Workaround for image building in Flutter 3.29 based on https://github.com/flutter/flutter/issues/163308#issuecomment-2676366371

Also updated the android image from https://github.com/cirruslabs/docker-images-android/pull/78