### PR TITLE
Add note in README pointing to community fork continuing image updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 > [!IMPORTANT]
 > This repostiry will stop updating images starting May 1st 2026 due to Cirrus Labs winding down operations after an acquisition.
+>
+> A community-maintained fork that continues publishing updated images is available at [`adrianjagielak/docker-images-flutter`](https://github.com/adrianjagielak/docker-images-flutter). It is independent and not affiliated with or endorsed by Cirrus Labs or OpenAI.
 
 # Docker Images for [Flutter](https://flutter.dev/)
 


### PR DESCRIPTION
The existing IMPORTANT block says image updates stop on May 1st 2026. Anyone who lands on the README after that date is going to look for where the same image is still being built. This PR adds two sentences to the same block pointing them at a community-maintained fork I've stood up.

The fork mirrors the build pipeline (same `sdk/Dockerfile`, same tag scheme: `stable`, `beta`, exact versions like `3.41.9`, multi-arch on GHCR), so for most users it's a drop-in registry swap (`ghcr.io/cirruslabs/flutter` -> `ghcr.io/adrianjagielak/flutter`).

A few notes to make this easy to merge or reject:

- No endorsement implied: The note explicitly states the fork is independent and not affiliated with or endorsed by Cirrus Labs or OpenAI. Happy to reword if you'd prefer different framing (e.g. "third-party fork", "unaffiliated fork", or just dropping the mention entirely).
- No ask: I'm not requesting a transfer, a redirect, ownership of the GHCR package, or anything beyond this README pointer. I'll maintain the fork on a best-effort, volunteer basis.
- Easy to revert: If you change your mind later, it's a one-commit revert.

I understand if the answer is "no thanks"; in that case feel free to close. Posting it because I think it saves users a search, and the existing notice is the natural place to point them. Thanks for years of maintaining these images!